### PR TITLE
Updated the ethers v6 methods in getBalance and fund functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function fund() {
     const contract = new ethers.Contract(contractAddress, abi, signer)
     try {
       const transactionResponse = await contract.fund(2, "0x0000000000000000000000000000000000000000", {
-        value: ethers.utils.parseEther(ethAmount),
+        value: ethers.parseEther(ethAmount),
       })
       await transactionResponse.wait(1)
     } catch (error) {
@@ -68,10 +68,10 @@ async function fund() {
 
 async function getBalance() {
   if (typeof window.ethereum !== "undefined") {
-    const provider = new ethers.providers.Web3Provider(window.ethereum)
+    const provider = new ethers.BrowserProvider(window.ethereum)
     try {
       const balance = await provider.getBalance(contractAddress)
-      console.log(ethers.utils.formatEther(balance))
+      console.log(ethers.formatEther(balance))
     } catch (error) {
       console.log(error)
     }


### PR DESCRIPTION
The ethers version 6 methods needed to be updated in getBalance and fund functions.

It was throwing following errors.


1. Calling getBalance function throws the following error
<img width="719" alt="Screenshot 2024-07-09 at 10 16 01 AM" src="https://github.com/Cyfrin/html-fund-me-cu/assets/12666706/c0996852-9e9d-443e-8a5d-1ddd59358942">

**Solution:** Instead of `ethers.providers.Web3Provider(window.ethereum)` , it should be `ethers.BrowserProvider(window.ethereum)`


2. Calling fund function thrown the following error
<img width="543" alt="Screenshot 2024-07-09 at 10 16 22 AM" src="https://github.com/Cyfrin/html-fund-me-cu/assets/12666706/c014f88a-a641-4dc4-a11a-5953cebb80e0">

**Solution:** 
Instead of `ethers.utils.parseEther` , it should be `ethers.parseEther`

